### PR TITLE
Make Morphix compliant with elixir >= 1.10

### DIFF
--- a/lib/morphix.ex
+++ b/lib/morphix.ex
@@ -859,5 +859,7 @@ defmodule Morphix do
     is_map(map) && not Map.has_key?(map, :__struct__) && Enum.empty?(map)
   end
 
-  defp is_struct(s), do: is_map(s) and Map.has_key?(s, :__struct__)
+  if !macro_exported?(Kernel, :is_struct, 1) do
+    defp is_struct(s), do: is_map(s) and Map.has_key?(s, :__struct__)
+  end
 end


### PR DESCRIPTION
Since Elixir 1.10.0-rc.0 added `is_struct` guard, Morphix refuses to compile on it (since we're defining the function as the same name as guard present in and imported from Kernel).

That PR adds conditional check, defining is_struct only if it's needed.